### PR TITLE
Feature/edit profile: Personalize profile #24

### DIFF
--- a/index.html
+++ b/index.html
@@ -650,7 +650,39 @@
                       Course where you play most of your speedgolf.
                     </div>
                   </div>
-                  <!-- Todo: Best score and clubs fields -->
+                    <fieldset>
+                      <legend class="fm-legend-sm">Best 18-Hole Speedgolf Score (optional)</legend>
+                      <div class="mb-3">
+                        <label for="sgBestStrokes" class="form-label">Strokes:
+                            <input id="sgBestStrokes" type="number" class="form-control centered"
+                            min="36" max="200"
+                            aria-describedby="sgBestScoreDescr">
+                        </label>
+                        <label for="sgBestMinutes" class="form-label">Minutes:
+                          <input id="sgBestMinutes" type="number" class="form-control centered"
+                          min="36" max="200"
+                          aria-describedby="sgBestScoreDescr">
+                        </label>
+                        <label for="sgBestSeconds" class="form-label">Seconds:
+                          <input id="sgBestSeconds" type="number" class="form-control centered"
+                          min="0" max="59"
+                          aria-describedby="sgBestScoreDescr">
+                        </label>
+                        <div id="sgBestScoreDescr" class="form-text">
+                          Personal best speedgolf round in strokes (18-200), minutes (18-200), and seconds (0-59) taken. 
+                        </div>
+                      </div>
+                      <div class="mb-3">
+                        <label for="sgBestCourse" class="form-label">Course Where Best Score Attained (optional):
+                          <input id="sgBestCourse" type="text" class="form-control centered"
+                          aria-describedby="sgBestCourseDescr" minlength="10">
+                        </label>
+                        <div id="sgBestCourseDescr" class="form-text">
+                          Name of course where you shot your best speedgolf score. Must be at least 10 characters. 
+                        </div>
+                      </div>
+                    </fieldset>
+                    <!-- Todo: Clubs in bag fieldset -->
                   </div>
                 </div>
               </fieldset>

--- a/index.html
+++ b/index.html
@@ -495,6 +495,38 @@
           </div>
         </form>
       </div>
+      <div id="profileSettingsDialog" class="mode-page hidden"
+      role="dialog" aria-modal="true" 
+      aria-labelledby="accountProfileHeader">
+        <h1 id="accountProfileHeader" class="mode-page-header">Account & Profile</h1>
+        <p id="profileErrorBox" class="alert alert-danger centered hidden">
+          <a id="profileEmailError" href="#profileEmail" class="alert-link">Enter a valid email address<br/></a>
+          <a id="profileDisplayNameError" href="#profileDisplayName" class="alert-link">Enter a valid display name<br/></a>
+          <a id="profileSecurityQuestionError" href="#profileSecurityQuestion" class="alert-link">Enter a valid security question<br/></a>
+          <a id="profileSecurityAnswerError" href="#profileSecurityAnswer" class="alert-link">Enter a valid security question answer</a>
+        </p>
+        <form id="editProfileForm" class="centered" novalidate>
+          <div id="profileFormAccordion" class="accordion">
+            <!-- Todo: Account, Name & Picture, and Speedgolf Info panels -->
+          </div>
+          <div class="mode-page-btn-container">
+            <button type="submit" id="submitUpdateProfileBtn" 
+                class="btn btn-primary dialog-primary-btn" 
+                aria-live="polite" aria-busy="false">
+              <span id="editProfileBtnIcon" 
+                class="fas fa-user-edit" 
+                aria-hidden="true"></span>
+                &nbsp;Update
+            </button>
+            <button type="button" id="cancelUpdateProfileBtn" 
+                class="btn btn-secondary dialog-cancel-btn">
+                <span class="fas fa-window-close" 
+                aria-hidden="true"></span>
+              &nbsp;Cancel
+            </button>
+          </div>
+        </form>
+      </div>
     </main>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
     <script src="scripts/main.js"></script>

--- a/index.html
+++ b/index.html
@@ -571,7 +571,48 @@
                 </div>
               </fieldset>
             </div>
-            <!-- Todo: Name & Picture and Speedgolf Info panels -->
+              <div class="accordion-item">
+                <fieldset>
+                  <h2 id="profileHeader" class="accordion-header">
+                    <button id="profileSettingsBtn" class="accordion-button collapsed" type="button"
+                      data-bs-toggle="collapse" data-bs-target="#profileSettingsPanel" 
+                      aria-expanded="false" 
+                      aria-controls="profileSettingsPanel">
+                      <legend>Name & Picture</legend>
+                    </button>
+                  </h2>
+                  <div id="profileSettingsPanel" class="accordion-collapse collapse"
+                    aria-labelledby="profileHeader" data-bs-parent="#profileFormAccordion">
+                    <div class="accordion-body">
+                      <div class="mb-3">
+                        <label for="profileDisplayName" class="form-label">Display Name:<br/>
+                            <input id="profileDisplayName" type="text" class="form-control centered"
+                            minlength="5"
+                            aria-describedby="profileDisplayNameDescr"
+                            required>
+                        </label>
+                        <div id="profileDisplayNameDescr" class="form-text">
+                          Your display name is your identity within SpeedScore. It must be at least 5 characters.
+                        </div>
+                      </div>
+                      <div class="mb-3">
+                        <label for="profilePic" class="form-label">Profile Picture (optional):<br/>
+                          <img id="profilePicImage" src="images/DefaultProfilePic.jpg" 
+                                class="fm-profile-pic" height="46" width="auto"/>
+                            <input id="profilePic" type="file" class="form-control centered"
+                            accept=".png, .gif, .jpg"
+                            aria-describedby="profilePicDescr"
+                            required>
+                        </label>
+                        <div id="profilePicDescr" class="form-text">
+                          Upload a profile picture as a .png, .gif, or .jpg file. A rectangular head shot works best.
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </fieldset>
+              </div>
+              <!-- Todo: Speedgolf Info panel -->
           </div>
           <div class="mode-page-btn-container">
             <button type="submit" id="submitUpdateProfileBtn" 

--- a/index.html
+++ b/index.html
@@ -682,7 +682,80 @@
                         </div>
                       </div>
                     </fieldset>
-                    <!-- Todo: Clubs in bag fieldset -->
+                    <fieldset>
+                      <legend class="fm-legend-sm">Clubs in Bag (optional)</legend>
+                      <div id="clubsDiv" class="mb-3">
+                        <input id="sgDriver" type="checkbox" name="Driver"
+                        aria-describedby="sgClubsDescr">
+                        <label for="sgDriver">Driver</label>
+                        <input id="sg3W" type="checkbox" name="3W"
+                        aria-describedby="sgClubsDescr">
+                        <label for="sg3W">3W</label>
+                        <input id="sg4W" type="checkbox" name="4W"
+                        aria-describedby="sgClubsDescr">
+                        <label for="sg4W">4W</label>
+                        <input id="sg5W" type="checkbox" name="5W"
+                        aria-describedby="sgClubsDescr">
+                        <label for="sg5W">5W</label>
+                        <input id="sgHybrid" type="checkbox" name="Hybrid"
+                        aria-describedby="sgClubsDescr">
+                        <label for="sgHybrid">Hybrid</label>
+                        <br/>
+                        <input id="sg1I" type="checkbox" name="1I"
+                        aria-describedby="1I">
+                        <label>1I</label>
+                        <input id="sg2I" type="checkbox" name="2I"
+                        aria-describedby="sgClubsDescr">
+                        <label for="sg2I">2I</label>
+                        <input id="sg3I" type="checkbox" name="3I"
+                        aria-describedby="sgClubsDescr">
+                        <label for="sg3I">3I</label>
+                        <input id="sg4I" type="checkbox" name="4I"
+                        aria-describedby="sgClubsDescr">
+                        <label for="sg4I">4I</label>
+                        <input id="sg5I" type="checkbox" name="5I"
+                        aria-describedby="sgClubsDescr">
+                        <label for="sg5I">5I</label>
+                        <input id="sg6I" type="checkbox" name="6I"
+                        aria-describedby="sgClubsDescr">
+                        <label for="sg6I">6I</label>
+                        <input id="sg7I" type="checkbox" name="7I"
+                        aria-describedby="sgClubsDescr">
+                        <label for="sg7I">7I</label>
+                        <input id="sg8I" type="checkbox" name="8I"
+                        aria-describedby="sgClubsDescr">
+                        <label for="sg8I">8I</label>
+                        <input id="sg9I" type="checkbox" name="9I"
+                        aria-describedby="sgClubsDescr">
+                        <label for="sg9I">9I</label>
+                        <br/>
+                        <input id="sgPW" type="checkbox" name="PW"
+                        aria-describedby="sgClubsDescr">
+                        <label for="sgPW">PW</label>
+                        <input id="sgGW" type="checkbox" name="GW"
+                        aria-describedby="sgClubsDescr">
+                        <label for="sgGW">GW</label>
+                        <input id="sgSW" type="checkbox" name="SW"
+                        aria-describedby="sgClubsDescr">
+                        <label for="sgSW">SW</label>
+                        <input id="sgLW" type="checkbox" name="LW"
+                        aria-describedby="sgClubsDescr">
+                        <label for="sgLW">LW</label>
+                        <br/>
+                        <input id="sgPutter" type="checkbox" name="Putter"
+                        aria-describedby="sgClubsDescr">
+                        <label for="sgPutter">Putter</label>
+                        <div id="sgClubsDescr" class="form-text">
+                          Select the clubs you normally carry during a speedgolf round. 
+                        </div>
+                        <label for="sgClubComments" class="form-label">Comments on Clubs (optional):</label>
+                        <textarea id="sgClubComments" class="form-control"
+                          aria-describedby="sgClubCommentsDescr"></textarea>
+                        <div id="sgClubCommentsDescr" class="form-text">
+                          Describe your clubs in greater detail. 
+                        </div>
+                      </div>
+                    </fieldset>
                   </div>
                 </div>
               </fieldset>

--- a/index.html
+++ b/index.html
@@ -634,7 +634,15 @@
                         A short personal bio about your speedgolf journey. Maximum of 500 characters.
                       </div>
                     </div>
-                    <!-- Todo: First round, home course, best score, and clubs fields -->
+                    <div class="mb-3">
+                      <label for="sgFirstRound" class="form-label">Date of First Speedgolf Round (optional):</label>
+                        <input type="month" id="sgFirstRound" class="form-control centered"
+                          value="2021-07" aria-describedby="sgFirstRoundDescr">
+                      <div id="sgFirstRoundDescr" class="form-text">
+                        Month and year in which you played your first speedgolf round.
+                      </div>
+                    </div>
+                    <!-- Todo: Home course, best score, and clubs fields -->
                   </div>
                 </div>
               </fieldset>

--- a/index.html
+++ b/index.html
@@ -507,7 +507,48 @@
         </p>
         <form id="editProfileForm" class="centered" novalidate>
           <div id="profileFormAccordion" class="accordion">
-            <!-- Todo: Account, Name & Picture, and Speedgolf Info panels -->
+            <div class="accordion-item">
+              <fieldset>
+                <h2 class="accordion-header" id="accountHeader">
+                  <button id="accountSettingsBtn" class="accordion-button" type="button"
+                    data-bs-toggle="collapse" data-bs-target="#accountSettingsPanel" 
+                    aria-expanded="true" 
+                    aria-controls="accountSettingsPanel">
+                    <legend>Account</legend>
+                  </button>
+                </h2>
+                <div id="accountSettingsPanel" 
+                    class="accordion-collapse collapse show" 
+                    aria-labelledby="accountHeader" 
+                    data-bs-parent="#profileFormAccordion">
+                  <div class="accordion-body">
+                    <div class="mb-3">
+                      <label for="profileEmail" class="form-label">Email:
+                          <input id="profileEmail" type="email" class="form-control centered"
+                          aria-describedby="profileEmailDescr"
+                          required>
+                      </label>
+                      <div id="profileEmailDescr" class="form-text">
+                        Enter a valid email address (e.g., 'name@domain.com').
+                      </div>
+                    </div>
+                    <div class="mb-3">
+                      <label for="profilePassword" class="form-label">Password:
+                          <input id="profilePassword" type="password" class="form-control centered"
+                          pattern="^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[a-zA-Z]).{8,}$"
+                          aria-describedby="profilePasswordDescr"
+                          readonly>
+                      </label>
+                      <div id="profilePasswordDescr" class="form-text">
+                        Use the "Reset Password" option on the Log In page to reset your password.
+                      </div>
+                    </div>
+                    <!-- Todo: Security question and answer fields -->
+                  </div>
+                </div>
+              </fieldset>
+            </div>
+            <!-- Todo: Name & Picture and Speedgolf Info panels -->
           </div>
           <div class="mode-page-btn-container">
             <button type="submit" id="submitUpdateProfileBtn" 

--- a/index.html
+++ b/index.html
@@ -612,7 +612,33 @@
                   </div>
                 </fieldset>
               </div>
-              <!-- Todo: Speedgolf Info panel -->
+            <div class="accordion-item">
+              <fieldset>
+                <h2 id="sgHeader" class=accordion-header>
+                  <button id="sgSettingsBtn" class="accordion-button collapsed" type="button"
+                    data-bs-toggle="collapse" data-bs-target="#sgSettingsPanel" 
+                    aria-expanded="false" 
+                    aria-controls="sgSettingsPanel">
+                    <legend>Speedgolf Info</legend>
+                  </button>
+                </h2>
+                <div id="sgSettingsPanel" class="accordion-collapse collapse"
+                    aria-labelledby="sgHeader" data-bs-parent="#profileFormAccordion">
+                  <div class="accordion-body">
+                    <div class="mb-3">
+                      <label for="sgBio" class="form-label">Personal Speedgolf Bio (optional):</label>
+                        <textarea id="sgBio" class="form-control"
+                          aria-describedby="sgBioDescr" rows="5" cols="40" maxlength="500">
+                        </textarea>
+                      <div id="sgBioDescr" class="form-text">
+                        A short personal bio about your speedgolf journey. Maximum of 500 characters.
+                      </div>
+                    </div>
+                    <!-- Todo: First round, home course, best score, and clubs fields -->
+                  </div>
+                </div>
+              </fieldset>
+            </div>
           </div>
           <div class="mode-page-btn-container">
             <button type="submit" id="submitUpdateProfileBtn" 

--- a/index.html
+++ b/index.html
@@ -642,7 +642,15 @@
                         Month and year in which you played your first speedgolf round.
                       </div>
                     </div>
-                    <!-- Todo: Home course, best score, and clubs fields -->
+                    <div class="mb-3">
+                    <label for="sgHomeCourser" class="form-label">Home Course (optional):</label>
+                      <input type="text" id="sgHomeCourse" class="form-control centered"
+                        aria-describedby="sgHomeCourseDescr">
+                    <div id="sgHomeCourseDescr" class="form-text">
+                      Course where you play most of your speedgolf.
+                    </div>
+                  </div>
+                  <!-- Todo: Best score and clubs fields -->
                   </div>
                 </div>
               </fieldset>

--- a/index.html
+++ b/index.html
@@ -543,7 +543,30 @@
                         Use the "Reset Password" option on the Log In page to reset your password.
                       </div>
                     </div>
-                    <!-- Todo: Security question and answer fields -->
+                    <div class="mb-3">
+                    <label for="profileSecurityQuestion" class="form-label">Security Question:
+                        <input id="profileSecurityQuestion" type="text" class="form-control centered"
+                        minlength="5"
+                        aria-describedby="profileSecurityQuestionDescr"
+                        required>
+                    </label>
+                    <div id="profileSecurityQuestionDescr" class="form-text">
+                      Your security question must be at least 5 characters and should have a memorable answer. You will be asked
+                      this question if you ever need to reset your password.
+                    </div>
+                  </div>
+                    <div class="mb-3">
+                      <label for="profileSecurityAnswer" class="form-label">Answer to Security Question:
+                          <input id="profileSecurityAnswer" type="text" class="form-control centered"
+                          minlength="5"
+                          aria-describedby="profileSecurityAnswerDescr"
+                          required>
+                      </label>
+                      <div id="profileSecurityAnswerDescr" class="form-text">
+                        Your security answer must be at least 5 characters and should be something you easily associate
+                        your security question. You will have to provide this answer if you ever need to reset your password.
+                      </div>
+                    </div>
                   </div>
                 </div>
               </fieldset>

--- a/index.html
+++ b/index.html
@@ -41,11 +41,10 @@
             aria-label="Search">
             <span class="navbar-btn-icon fas fa-search"></span>
             </button>
-            <button id="profileBtn" type="button" class="navbar-btn hidden" title="Edit Profile"
-            aria-label="Account Settings">
-            <img class="navbar-profile-pic" 
-                src="images/ChrisProfilePic.jpg" alt="User's profile picture">
-            </button>  
+            <button id="profileBtn" type="button" 
+              class="navbar-btn navbar-profile-btn hidden" 
+              aria-label="Account and Profile Settings">
+            </button>
         </div>
    <body>
 
@@ -790,5 +789,6 @@
     <script src="https://www.w3schools.com/lib/w3.js"></script>
     <script src="scripts/login.js"></script>
     <script src="scripts/createAccount.js"></script>
+    <script src="scripts/editProfile.js"></script>
   </body>
 </html>

--- a/scripts/editProfile.js
+++ b/scripts/editProfile.js
@@ -1,0 +1,299 @@
+/*************************************************************************
+ * File: editProfile.js
+ * This file contains functions that support the "Account and Profile
+ * Settings" Dialog.
+ ************************************************************************/
+
+ /*************************************************************************
+ * @function profilePicField CHANGE Handler 
+ * @Desc 
+ * When the user finishes interacting with the File picker dialog box,
+ * update the user's profile picture based on the selection from the
+ * file picker. If the user cancels out of the File Picker, the input
+ * element's value will be empty and we set the profile picture to the
+ * default picture.
+ * @global profilePicField: The "Update Profile" form field 
+ *         containing the optional profile picture
+ * @global profilePicImage: The "Update Profile" <img> element that
+ *         displays the user's profile picture (possibly the default)
+ *************************************************************************/
+  GlobalProfilePicField.addEventListener("change",function(e) {
+    if (GlobalProfilePicField.value.length !== 0) {
+        const reader = new FileReader();
+        reader.readAsDataURL(GlobalProfilePicField.files[0]);
+        reader.addEventListener("load",function() {
+            GlobalProfilePicImage.setAttribute("src",this.result);
+        });
+    } else {
+        GlobalProfilePicImage.setAttribute("src",GlobalDefaultProfilePic);
+    }
+});
+
+/*************************************************************************
+ * @function resetupdateProfileForm 
+ * @Desc 
+ * When the user exits the "Update Profile" Dialog, reset the form to
+ * blank in case the form is visited again.
+ * @global GlobalProfileEmailFiled: Form's email field
+ * @global GlobalProfilePasswordField: Form's password field
+ * @global GlobalProfileDisplayNameField: Form's display name field
+ * @global GlobalProfileSecurityQuestionField: Form's security q field
+ * @global GlobalProfileSecurityAnswerField: Form's security answ field
+ * @global GlobalProfileErrBox: <div> containing the error messages
+ * @global GlobalProfileEmailErr: Error message for email field
+ * @global GlobalProfilePasswordErr: Error message for password field
+ * @global GlobalProfileDisplaynameErr: Error message for display name field
+ * @global GlobalProfileSecurityQuestionErr: Error message for security q field
+ * @global GlobalProfileSecurityAnswerErr: Error message for security answ field
+ *************************************************************************/
+ function resetUpdateProfileForm() {
+    //Hide errors
+    GlobalProfileErrBox.classList.add("hidden");
+    GlobalProfileEmailErr.classList.add("hidden");
+    GlobalProfileDisplayNameErr.classList.add("hidden");
+    GlobalProfileSecurityQuestionErr.classList.add("hidden");
+    GlobalProfileSecurityAnswerErr.classList.add("hidden");
+    //Blank out account info
+    GlobalProfileEmailField.value = "";
+    GlobalProfilePasswordField.value = "";
+    GlobalProfileSecurityQuestionField.value = "";
+    GlobalProfileSecurityAnswerField.value = "";
+    //Blank out Identity info
+    GlobalProfileDisplayNameField.value = "";
+    GlobalProfilePicField.value = "";
+    GlobalProfilePicImage.setAttribute("src",GlobalDefaultProfilePic);
+    //Blank out Speedgolf info
+    GlobalProfileBioField.value = "";
+    GlobalProfileFirstRoundField.value = "";
+    GlobalProfileHomeCourseField.value = "";
+    GlobalProfileBestStrokesField.value = "";
+    GlobalProfileBestMinutesField.value = "";
+    GlobalProfileBestSecondsField.value = "";
+    GlobalProfileBestCourseField.value = "";
+    for (let i = 0; i < GlobalAllClubs.length; ++i) {
+        document.getElementById("sg"+ GlobalAllClubs[i]).checked = false;
+    }
+    GlobalProfileClubCommentsField.value = "";
+    //Set first focusable item.
+    GlobalFirstFocusableUpdateProfileItem.set(GlobalProfileEmailField);
+    //Expand only the first accordion panel
+    GlobalAccountSettingsBtn.classList.remove("collapsed");
+    GlobalAccountSettingsPanel.classList.add("show");
+    GlobalProfileSettingsBtn.classList.add("collapsed");
+    GlobalProfileSettingsPanel.classList.remove("show");
+    GlobalsgSettingsBtn.classList.add("collapsed");
+    GlobalsgSettingsPanel.classList.remove("show");
+}
+
+/*************************************************************************
+ * @function populateProfileSettingsForm 
+ * @Desc 
+ * Populates the "Account and Profile Settings" dialog form with the 
+ * current user's data. 
+ * The following global vars are used to access fields in the form
+ *  @global GlobalProfileEmailField
+ *  @global GlobalProfilePasswordField
+ *  @global GlobalProfileSecurityQuestionField
+ *  @global GlobalProfileSecurityAnswerField
+ *  @global GlobalProfileDisplayNameField
+ *  @global GlobalProfilePicImage
+ *  @global GlobalProfileBioField    
+ *  @global GlobalProfileBestStrokesField
+ *  @global GlobalProfileBestMinutesField
+ *  @global GlobalProfileBestSecondsField
+ *  @global GlobalProfileBestCourseField
+ *************************************************************************/
+ function populateProfileSettingsForm() {
+    GlobalProfileEmailField.value = GlobalUserData.accountInfo.email;
+    GlobalProfilePasswordField.value = GlobalUserData.accountInfo.password;
+    GlobalProfileSecurityQuestionField.value = GlobalUserData.accountInfo.securityQuestion;
+    GlobalProfileSecurityAnswerField.value = GlobalUserData.accountInfo.securityAnswer;
+    GlobalProfileDisplayNameField.value = GlobalUserData.identityInfo.displayName;
+    GlobalProfilePicImage.setAttribute("src",GlobalUserData.identityInfo.profilePic);
+    GlobalProfileBioField.value = GlobalUserData.speedgolfInfo.bio;
+    GlobalProfileHomeCourseField.value = GlobalUserData.speedgolfInfo.homeCourse;
+    GlobalProfileFirstRoundField.value = GlobalUserData.speedgolfInfo.firstRound;
+    GlobalProfileBestStrokesField.value = GlobalUserData.speedgolfInfo.personalBest.strokes;
+    GlobalProfileBestMinutesField.value = GlobalUserData.speedgolfInfo.personalBest.minutes;
+    GlobalProfileBestSecondsField.value = GlobalUserData.speedgolfInfo.personalBest.seconds;
+    GlobalProfileBestCourseField.value = GlobalUserData.speedgolfInfo.personalBest.course;   
+    //Check checkboxes...
+    for (const prop in GlobalUserData.speedgolfInfo.clubs) {
+        document.getElementById("sg" + prop).checked = true;
+    }
+    GlobalProfileClubCommentsField.value = GlobalUserData.speedgolfInfo.clubComments;
+    GlobalProfileEmailField.focus(); //Set focus to first field.
+}
+
+/*************************************************************************
+ * @function profileBtn CLICK Handler 
+ * @Desc 
+ * When the user clicks their profile picture, hide the menu button, tabs,
+ * and current tab panel, and show the "Account and Profile Settings" Dialog
+ * @global GlobalMenuBtn: The menu button
+ * @global GlobalModeTabsContainer: The mode tabs
+ * @global GlobalModeTabPanels: array of tab panels 
+ * @global GlobalCurrentMode, index of current mode.
+ * @global GlobalProfileSettingsDialog: The "Account and Profile Settings" 
+ *         dialog
+ *************************************************************************/
+ GlobalProfileBtn.addEventListener("click", function(e) {
+    transitionToDialog(GlobalProfileSettingsDialog, "Edit Account and Profile",populateProfileSettingsForm);
+    //populateProfileSettingsForm();
+    GlobalProfileEmailField.focus();
+});
+
+/*************************************************************************
+ * @function updateProfile
+ * @Desc 
+ * Given valid profile data in the form, update the current user's
+ * object in localStorage
+ * @global menuBtn: The menu button
+ * @global modeTabsContainer: The mode tabs
+ * @global modeTabPanels: array of tab panels 
+ * @global currentMode, index of current mode.
+ * @global profileSettingsDialog: The "Account and Profile Settings" 
+ *         dialog
+ *************************************************************************/
+ function updateProfile() {
+    let clubsInBag = {};
+    for (let i = 0; i < GlobalProfileClubsInBagChecks.length; ++i) {
+        if (GlobalProfileClubsInBagChecks[i].checked) {
+            clubsInBag[GlobalProfileClubsInBagChecks[i].name] = true;
+        }
+    }
+    const oldUserEmail = GlobalUserData.accountInfo.email;
+    GlobalUserData = {
+        accountInfo: {
+            email: GlobalProfileEmailField.value, 
+            password: GlobalProfilePasswordField.value,
+            securityQuestion: GlobalProfileSecurityQuestionField.value,
+            securityAnswer: GlobalProfileSecurityAnswerField.value
+        },
+        identityInfo: {
+            displayName: GlobalProfileDisplayNameField.value,
+            profilePic: GlobalProfilePicImage.getAttribute("src"),
+        },
+        speedgolfInfo: {
+            bio: GlobalProfileBioField.value,
+            firstRound: GlobalProfileFirstRoundField.value,
+            homeCourse: GlobalProfileHomeCourseField.value,
+            personalBest: {
+                strokes: GlobalProfileBestStrokesField.value,
+                minutes: GlobalProfileBestMinutesField.value, 
+                seconds: GlobalProfileBestSecondsField.value, 
+                course: GlobalProfileBestCourseField.value},
+            clubs: clubsInBag,
+            clubComments: GlobalProfileClubCommentsField.value
+        },
+        rounds: [...GlobalUserData.rounds],
+        roundCount: GlobalUserData.roundCount
+    };
+    //Save updated profile to localStorage as key-value pair
+    localStorage.setItem(GlobalUserData.accountInfo.email, 
+        JSON.stringify(GlobalUserData));
+    if (oldUserEmail !== GlobalUserData.accountInfo.email) {
+        //We need to remove old user record from localStorage
+        localStorage.removeItem(oldUserEmail);
+    }
+    //Reset form in case it is visited again
+    resetUpdateProfileForm();
+    //Transition back to previous mode page
+    GlobalProfileBtn.style.backgroundImage = "url(" + GlobalUserData.identityInfo.profilePic + ")";
+    transitionFromDialog(GlobalProfileSettingsDialog);
+}
+
+/*************************************************************************
+ * @function submit button CLICK Handler 
+ * @Desc 
+ * When the user clicks the form's "Update" (submit) button, we need to
+ * validate the form data. If it's valid, we update the current user's
+ * object in localStorage.
+ * @global GlobalMenuBtn: The menu button
+ * @global GlobalModeTabsContainer: The mode tabs
+ * @global GlobalModeTabPanels: array of tab panels 
+ * @global GlobalCurrentMode, index of current mode.
+ * @global GlobalProfileSettingsDialog: The "Account and Profile Settings" 
+ *         dialog
+ *************************************************************************/
+ editProfileForm.addEventListener("submit",function(e) {
+    e.preventDefault(); //Prevent default submit behavior
+    //Is the email field valid?
+    let emailValid = !GlobalProfileEmailField.validity.typeMismatch && 
+                        !GlobalProfileEmailField.validity.valueMissing;
+    //Is display field valid?
+    let displayNameValid = !GlobalProfileDisplayNameField.validity.tooShort &&
+                            !GlobalProfileDisplayNameField.validity.valueMissing;
+    //Is security question field valid?
+    let securityQuestionValid = !GlobalProfileSecurityQuestionField.validity.tooShort &&
+                                !GlobalProfileSecurityQuestionField.validity.valueMissing;
+    //Is security answer field valid?
+    let securityAnswerValid = !GlobalProfileSecurityAnswerField.validity.tooShort &&
+                                !GlobalProfileSecurityAnswerField.validity.valueMissing;
+    if (emailValid && displayNameValid && 
+        securityQuestionValid & securityAnswerValid) { 
+        //All is well -- Call updateProfile()
+        updateProfile();
+        return;
+    }
+    //If here, at least one field is invalid: Display the errors
+    //and allow user to fix them.
+    GlobalProfileErrBox.classList.remove("hidden");
+    if (!emailValid || !securityQuestionValid || !securityAnswerValid) {
+        //expand account panel
+        accountSettingsBtn.classList.remove("collapsed");
+        accountSettingsPanel.classList.add("show");
+    } else {
+        //collapse account panel
+        accountSettingsBtn.classList.add("collapsed");
+        accountSettingsPanel.classList.remove("show");
+    }
+    if (!displayNameValid) {
+        //expand Profile panel
+        GlobalProfileSettingsBtn.classList.remove("collapsed");
+        GlobalProfileSettingsPanel.classList.add("show");
+    } else {
+        //collapse account panel
+        GlobalProfileSettingsBtn.classList.add("collapsed");
+        GlobalProfileSettingsPanel.classList.remove("show");
+    }
+    //Speedgolf Settings Panel always collapsed
+    GlobalsgSettingsBtn.classList.add("collapsed");
+    GlobalsgSettingsPanel.classList.remove("show");
+    document.title = "Error: Update Account & Profile";
+    if (!securityAnswerValid) { //Display name field is invalid
+        GlobalProfileSecurityAnswerErr.classList.remove("hidden");
+        GlobalProfileSecurityAnswerErr.focus();
+        GlobalFirstFocusableUpdateProfileItem.set(GlobalProfileSecurityAnswerErr);
+    } else {
+        GlobalProfileSecurityAnswerErr.classList.add("hidden");
+    }
+    if (!securityQuestionValid) { //Display name field is invalid
+        GlobalProfileSecurityQuestionErr.classList.remove("hidden");
+        GlobalProfileSecurityQuestionErr.focus();
+        GlobalFrstFocusableUpdateProfileItem.set(GlobalProfileSecurityQuestionErr);
+    } else {
+        GlobalProfileSecurityQuestionErr.classList.add("hidden");
+    } 
+    if (!displayNameValid) { //Display name field is invalid
+        GlobalProfileDisplayNameErr.classList.remove("hidden");
+        GlobalProfileDisplayNameErr.focus();
+        GlobalFirstFocusableUpdateProfileItem.set(GlobalProfileDisplayName);
+    } else {
+        GlobalProfileDisplayNameErr.classList.add("hidden");
+    } 
+    if (!emailValid) { //Email field is invalid
+        GlobalProfileEmailErr.classList.remove("hidden");
+        GlobalProfileEmailErr.focus();
+        GlobalFirstFocusableUpdateProfileItem.set(GlobalProfileEmailErr);
+    } else {
+        GlobalProfileEmailErr.classList.add("hidden");
+    }
+ });
+
+ cancelUpdateProfileBtn.addEventListener("click", function(e) {
+    //Reset form in case it is visited again
+    resetUpdateProfileForm();
+    //Transition back to previous mode page
+    transitionFromDialog(GlobalProfileSettingsDialog);
+ });

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -139,6 +139,26 @@ const GlobalFirstFocusableCreateAccountItem = (() => {
 const GlobalDefaultProfilePic = "images/DefaultProfilePic.jpg";
 
 /*****************************************************/
+/* ACCOUNT & SETTINGS DIALOG FORM                    */
+/*****************************************************/
+const GlobalProfileSettingsDialog = document.getElementById("profileSettingsDialog");
+const GlobalEditProfileForm = document.getElementById("editProfileForm");
+const GlobalProfileErrBox = document.getElementById("profileErrorBox");
+const GlobalProfileEmailErr = document.getElementById("profileEmailError");
+const GlobalProfileDisplayNameErr = document.getElementById("profileDisplayNameError");
+const GlobalProfileSecurityQuestionErr = document.getElementById("profileSecurityQuestionError");
+const GlobalProfileSecurityAnswerErr = document.getElementById("profileSecurityAnswerError");
+const GlobalCancelUpdateProfileBtn = document.getElementById("cancelUpdateProfileBtn");
+const GlobalFirstFocusableUpdateProfileItem = (() => {
+  let _firstFocusedUpdateProfileItem = GlobalAcctEmailField
+  const Store = {
+      get: () => _firstFocusedUpdateProfileItem,
+      set: val => (_firstFocusedUpdateProfileItem = val)
+  }
+  return Object.freeze(Store)
+})()
+
+/*****************************************************/
 /* OTHER UI COMPONENT VARIABLES */
 /*****************************************************/
 const GlobalSearchBtn = document.getElementById("searchBtn");

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -149,6 +149,10 @@ const GlobalProfileDisplayNameErr = document.getElementById("profileDisplayNameE
 const GlobalProfileSecurityQuestionErr = document.getElementById("profileSecurityQuestionError");
 const GlobalProfileSecurityAnswerErr = document.getElementById("profileSecurityAnswerError");
 const GlobalCancelUpdateProfileBtn = document.getElementById("cancelUpdateProfileBtn");
+const GlobalAccountSettingsBtn = document.getElementById("accountSettingsBtn");
+const GlobalAccountSettingsPanel = document.getElementById("accountSettingsPanel");
+const GlobalProfileEmailField = document.getElementById("profileEmail");
+const GlobalProfilePasswordField = document.getElementById("profilePassword");
 const GlobalFirstFocusableUpdateProfileItem = (() => {
   let _firstFocusedUpdateProfileItem = GlobalAcctEmailField
   const Store = {

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -188,3 +188,61 @@ const GlobalSearchBtn = document.getElementById("searchBtn");
 const GlobalProfileBtn = document.getElementById("profileBtn");
 const GlobalSkipLink = document.getElementById("sLink");
 const GlobalModeTabsContainer = document.getElementById("modeTabs");
+
+/*************************************************************************
+ * @function transitionToDialog
+ * @desc 
+ * This function prepares the UI prior to opening a dialog box. It hides
+ * the skip link, banner bar buttons, mode tabs, and current tab panel,
+ * so that they are unavailable while the user interacts with the dialog.
+ * It then displays the dialog box and dialog box title.
+ * Note: This function is placed in main.js because it is useful to 
+ * multiple UI components.
+ * @param dialogTitle: The title of the dialog to which to set 
+ * document.title
+ * @param dialog: A reference to the HTML element containing the dialog;
+ * it will be shown by removing the "hidden" class 
+ * @param dialogPrepFunc: A reference to a function to call to prepare 
+ * the dialog's appearance.
+ * @global GlobalSkipLink: The skip link
+ * @global GlobalMenuBtn: The menu button
+ * @global GlobalModeTabsContainer: The mode tabs
+ * @global GlobalModeTabPanels: array of tab panels 
+ * @global GlobalCurrentMode, index of current mode.
+ *************************************************************************/
+function transitionToDialog(dialog, dialogTitle, dialogPrepFunc) {
+  GlobalSkipLink.classList.add("hidden"); 
+  GlobalMenuBtn.classList.add("hidden");
+  GlobalSearchBtn.classList.add("hidden");
+  GlobalProfileBtn.classList.add("hidden");
+  GlobalModeTabsContainer.classList.add("hidden");
+  GlobalModeTabPanels[GlobalCurrentMode.get()].classList.add("hidden");
+  document.title = dialogTitle;
+  dialogPrepFunc();
+  dialog.classList.remove("hidden");
+}
+
+/*************************************************************************
+ * @function transitionFromDialog
+ * @param dialogToClose -- a reference to the HML dialog element to close
+ * @desc 
+ * This function restores the UI after closing a dialog box. It shows
+ * the skip link, banner bar buttons, mode tabs, and current tab panel,
+ * Note: This function is placed in main.js because it is useful to 
+ * multiple UI components.
+ * @global GlobalSkipLink: The skip link
+ * @global GlobalMenuBtn: The menu button
+ * @global GlobalModeTabsContainer: The mode tabs
+ * @global GlobalModeTabPanels: array of tab panels 
+ * @global GlobalCurrentMode, index of current mode.
+ *************************************************************************/
+function transitionFromDialog(dialogToClose) {
+  GlobalSkipLink.classList.remove("hidden"); 
+  GlobalMenuBtn.classList.remove("hidden");
+  GlobalSearchBtn.classList.remove("hidden");
+  GlobalProfileBtn.classList.remove("hidden");
+  GlobalModeTabsContainer.classList.remove("hidden");
+  GlobalModeTabPanels[GlobalCurrentMode.get()].classList.remove("hidden");
+  document.title = "SpeedScore: " + GlobalModeNames[GlobalCurrentMode.get()];
+  dialogToClose.classList.add("hidden");
+}

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -165,6 +165,10 @@ const GlobalsgSettingsPanel = document.getElementById("sgSettingsPanel");
 const GlobalProfileBioField = document.getElementById("sgBio");
 const GlobalProfileFirstRoundField = document.getElementById("sgFirstRound");
 const GlobalProfileHomeCourseField = document.getElementById("sgHomeCourse");
+const GlobalProfileBestStrokesField = document.getElementById("sgBestStrokes");
+const GlobalProfileBestMinutesField = document.getElementById("sgBestMinutes");
+const GlobalProfileBestSecondsField = document.getElementById("sgBestSeconds");
+const GlobalProfileBestCourseField = document.getElementById("sgBestCourse");
 const GlobalFirstFocusableUpdateProfileItem = (() => {
   let _firstFocusedUpdateProfileItem = GlobalAcctEmailField
   const Store = {

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -153,6 +153,8 @@ const GlobalAccountSettingsBtn = document.getElementById("accountSettingsBtn");
 const GlobalAccountSettingsPanel = document.getElementById("accountSettingsPanel");
 const GlobalProfileEmailField = document.getElementById("profileEmail");
 const GlobalProfilePasswordField = document.getElementById("profilePassword");
+const GlobalProfileSecurityQuestionField = document.getElementById("profileSecurityQuestion");
+const GlobalProfileSecurityAnswerField = document.getElementById("profileSecurityAnswer");
 const GlobalFirstFocusableUpdateProfileItem = (() => {
   let _firstFocusedUpdateProfileItem = GlobalAcctEmailField
   const Store = {

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -169,6 +169,9 @@ const GlobalProfileBestStrokesField = document.getElementById("sgBestStrokes");
 const GlobalProfileBestMinutesField = document.getElementById("sgBestMinutes");
 const GlobalProfileBestSecondsField = document.getElementById("sgBestSeconds");
 const GlobalProfileBestCourseField = document.getElementById("sgBestCourse");
+const GlobalAllClubs = ["Driver","3W","4W","5W","Hybrid","1I","2I","3I","4I","5I","6I","7I","8I","9I","PW","GW","SW","LW","Putter"];
+const GlobalProfileClubsInBagChecks = document.getElementById("clubsDiv").querySelectorAll("input");
+const GlobalProfileClubCommentsField = document.getElementById("sgClubComments");
 const GlobalFirstFocusableUpdateProfileItem = (() => {
   let _firstFocusedUpdateProfileItem = GlobalAcctEmailField
   const Store = {

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -155,6 +155,11 @@ const GlobalProfileEmailField = document.getElementById("profileEmail");
 const GlobalProfilePasswordField = document.getElementById("profilePassword");
 const GlobalProfileSecurityQuestionField = document.getElementById("profileSecurityQuestion");
 const GlobalProfileSecurityAnswerField = document.getElementById("profileSecurityAnswer");
+const GlobalProfileSettingsBtn = document.getElementById("profileSettingsBtn");
+const GlobalProfileSettingsPanel = document.getElementById("profileSettingsPanel");
+const GlobalProfileDisplayNameField = document.getElementById("profileDisplayName");
+const GlobalProfilePicField = document.getElementById("profilePic");
+const GlobalProfilePicImage = document.getElementById("profilePicImage");
 const GlobalFirstFocusableUpdateProfileItem = (() => {
   let _firstFocusedUpdateProfileItem = GlobalAcctEmailField
   const Store = {

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -163,6 +163,7 @@ const GlobalProfilePicImage = document.getElementById("profilePicImage");
 const GlobalsgSettingsBtn = document.getElementById("sgSettingsBtn");
 const GlobalsgSettingsPanel = document.getElementById("sgSettingsPanel");
 const GlobalProfileBioField = document.getElementById("sgBio");
+const GlobalProfileFirstRoundField = document.getElementById("sgFirstRound");
 const GlobalFirstFocusableUpdateProfileItem = (() => {
   let _firstFocusedUpdateProfileItem = GlobalAcctEmailField
   const Store = {

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -164,6 +164,7 @@ const GlobalsgSettingsBtn = document.getElementById("sgSettingsBtn");
 const GlobalsgSettingsPanel = document.getElementById("sgSettingsPanel");
 const GlobalProfileBioField = document.getElementById("sgBio");
 const GlobalProfileFirstRoundField = document.getElementById("sgFirstRound");
+const GlobalProfileHomeCourseField = document.getElementById("sgHomeCourse");
 const GlobalFirstFocusableUpdateProfileItem = (() => {
   let _firstFocusedUpdateProfileItem = GlobalAcctEmailField
   const Store = {

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -160,6 +160,9 @@ const GlobalProfileSettingsPanel = document.getElementById("profileSettingsPanel
 const GlobalProfileDisplayNameField = document.getElementById("profileDisplayName");
 const GlobalProfilePicField = document.getElementById("profilePic");
 const GlobalProfilePicImage = document.getElementById("profilePicImage");
+const GlobalsgSettingsBtn = document.getElementById("sgSettingsBtn");
+const GlobalsgSettingsPanel = document.getElementById("sgSettingsPanel");
+const GlobalProfileBioField = document.getElementById("sgBio");
 const GlobalFirstFocusableUpdateProfileItem = (() => {
   let _firstFocusedUpdateProfileItem = GlobalAcctEmailField
   const Store = {

--- a/styles/style.css
+++ b/styles/style.css
@@ -137,6 +137,20 @@
     margin-left: 16px;
 } 
 
+.navbar-profile-btn {
+    margin-left: 8px;
+    margin-right: 8px;
+    height: 44px;
+    width: 44px;
+    background-image: url("../images/DefaultProfilePic.jpg");
+    background-size: cover;
+    flex-shrink: 0;
+}
+
+.navbar-profile-pic {
+    background-size: cover;
+}
+
 /*************************************************************************
 * CSS CLASSES FOR SIDE MENU
 *************************************************************************/


### PR DESCRIPTION
This pull request implements user story #24, allowing speedgolfers to personalize their SpeedScore profiles. The changes add a new Account & Profile Settings dialog accessible via the profile button in the navbar, implemented across 10 commits.

Closes #24 — As a speedgolfer, I want to be able to personalize my profile
Closes #25 — Ability to update Bio
Closes #26 — Ability to update profile picture
Closes #31 — Ability to set date of first round
Closes #34 — Ability to add most played course
Closes #36 — Ability to add best score
Closes #39 — Ability to specify which clubs are in bag
Closes #54 — Ability to change email
Closes #55 — Ability to change security question